### PR TITLE
Use path.parse() from Node.js v8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/ChALkeR/compatible-path-parse/issues"
   },
   "dependencies": {
-    "packaged-path-parse": "~9.11.1"
+    "packaged-path-parse": "~8.11.1"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
The behavior is the same as in Node.js v9.x except for the error messages
on invalid input that were already behaving in packaged-path-parse@9.11.1
more like those in Node.js v8.x.

So this is a semver-patch change.

Full code diff between `index.js` of `packaged-path-parse@9.11.1` and `packaged-path-parse@8.11.1`:
```diff
1c1
< // packaged-path-parse - path.parse() extracted from Node.js v9.11.1
---
> // packaged-path-parse - path.parse() extracted from Node.js v8.11.1
29,38d28
<   var CHAR_UPPERCASE_A = 65;
<   var CHAR_LOWERCASE_A = 97;
<   var CHAR_UPPERCASE_Z = 90;
<   var CHAR_LOWERCASE_Z = 122;
<   var CHAR_DOT = 46;
<   var CHAR_FORWARD_SLASH = 47;
<   var CHAR_BACKWARD_SLASH = 92;
<   var CHAR_COLON = 58;
<   var CHAR_QUESTION_MARK = 63;
< 
41,46c31
<       throw new TypeError('ERR_INVALID_ARG_TYPE', 'path', 'string');
<     }
<   }
< 
<   function isPathSeparator(code) {
<     return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
---
>       throw new TypeError('Path must be a string. Received ' + path);
48,50d32
< 
<   function isWindowsDeviceRoot(code) {
<     return code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z || code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z;
65c47
<       if (isPathSeparator(code)) {
---
>       if (code === 47 /*/*/ || code === 92 /*\*/) {
67a50
>           code = path.charCodeAt(1);
69c52
<         if (isPathSeparator(path.charCodeAt(1))) {
---
>           if (code === 47 /*/*/ || code === 92 /*\*/) {
75c58,59
<             if (isPathSeparator(path.charCodeAt(j))) break;
---
>                 code = path.charCodeAt(j);
>                 if (code === 47 /*/*/ || code === 92 /*\*/) break;
82c66,67
<               if (!isPathSeparator(path.charCodeAt(j))) break;
---
>                   code = path.charCodeAt(j);
>                   if (code !== 47 /*/*/ && code !== 92 /*\*/) break;
89c74,75
<                 if (isPathSeparator(path.charCodeAt(j))) break;
---
>                     code = path.charCodeAt(j);
>                     if (code === 47 /*/*/ || code === 92 /*\*/) break;
103c89
<       } else if (isWindowsDeviceRoot(code)) {
---
>         } else if (code >= 65 /*A*/ && code <= 90 /*Z*/ || code >= 97 /*a*/ && code <= 122 /*z*/) {
106c92
<         if (path.charCodeAt(1) === CHAR_COLON) {
---
>         if (path.charCodeAt(1) === 58 /*:*/) {
109c95,96
<             if (isPathSeparator(path.charCodeAt(2))) {
---
>               code = path.charCodeAt(2);
>               if (code === 47 /*/*/ || code === 92 /*\*/) {
126c113
<     } else if (isPathSeparator(code)) {
---
>     } else if (code === 47 /*/*/ || code === 92 /*\*/) {
148c135
<       if (isPathSeparator(code)) {
---
>       if (code === 47 /*/*/ || code === 92 /*\*/) {
163c150
<       if (code === CHAR_DOT) {
---
>       if (code === 46 /*.*/) {
199c186,187
<     var isAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
---
>     var code = path.charCodeAt(0);
>     var isAbsolute = code === 47 /*/*/;
219,220c207,208
<       var code = path.charCodeAt(i);
<       if (code === CHAR_FORWARD_SLASH) {
---
>       code = path.charCodeAt(i);
>       if (code === 47 /*/*/) {
235c223
<       if (code === CHAR_DOT) {
---
>       if (code === 46 /*.*/) {
```